### PR TITLE
workflows: fix lava templates

### DIFF
--- a/.github/workflows/job_templates/mimxrt1060_boot.yaml
+++ b/.github/workflows/job_templates/mimxrt1060_boot.yaml
@@ -24,6 +24,10 @@ metadata:
   CI_TEST_3/CHECKIN: "successful"
   CI_TEST_3/ROLLBACK: "1"
 actions:
+- command:
+    name: serial_down
+- command:
+    name: serial_up
 - deploy:
     timeout:
       minutes: 15

--- a/.github/workflows/job_templates/mimxrt1060_boot_se050.yaml
+++ b/.github/workflows/job_templates/mimxrt1060_boot_se050.yaml
@@ -22,6 +22,12 @@ metadata:
   CI_TEST_3/CHECKIN: "successful"
   CI_TEST_3/ROLLBACK: "1"
 actions:
+- command:
+    namespace: cleanup
+    name: serial_down
+- command:
+    namespace: cleanup
+    name: serial_up
 - deploy:
     namespace: cleanup
     timeout:

--- a/.github/workflows/job_templates/mimxrt1060_boot_se050_el2go.yaml
+++ b/.github/workflows/job_templates/mimxrt1060_boot_se050_el2go.yaml
@@ -22,6 +22,12 @@ metadata:
   CI_TEST_3/CHECKIN: "successful"
   CI_TEST_3/ROLLBACK: "1"
 actions:
+- command:
+    namespace: cleanup
+    name: serial_down
+- command:
+    namespace: cleanup
+    name: serial_up
 - deploy:
     namespace: cleanup
     timeout:

--- a/.github/workflows/job_templates/mimxrt1170_boot.yaml
+++ b/.github/workflows/job_templates/mimxrt1170_boot.yaml
@@ -21,6 +21,10 @@ metadata:
   CI_TEST_3/CHECKIN: "successful"
   CI_TEST_3/ROLLBACK: "1"
 actions:
+- command:
+    name: serial_down
+- command:
+    name: serial_up
 - deploy:
     timeout:
       minutes: 15

--- a/.github/workflows/job_templates/mimxrt1170_boot_se050.yaml
+++ b/.github/workflows/job_templates/mimxrt1170_boot_se050.yaml
@@ -21,6 +21,12 @@ metadata:
   CI_TEST_3/CHECKIN: "successful"
   CI_TEST_3/ROLLBACK: "1"
 actions:
+- command:
+    namespace: cleanup
+    name: serial_down
+- command:
+    namespace: cleanup
+    name: serial_up
 - deploy:
     namespace: cleanup
     timeout:

--- a/.github/workflows/job_templates/mimxrt1170_boot_se050_el2go.yaml
+++ b/.github/workflows/job_templates/mimxrt1170_boot_se050_el2go.yaml
@@ -21,6 +21,12 @@ metadata:
   CI_TEST_3/CHECKIN: "successful"
   CI_TEST_3/ROLLBACK: "1"
 actions:
+- command:
+    namespace: cleanup
+    name: serial_down
+- command:
+    namespace: cleanup
+    name: serial_up
 - deploy:
     namespace: cleanup
     timeout:


### PR DESCRIPTION
Prevent problem with serial interruption when running a job. This happens when the serial line gets disconnected during the job. This patch makes sure the line is only disconnected at the beginning and not during the test job.